### PR TITLE
reverting macro BOOKING_API for static library

### DIFF
--- a/include/booking_manager.hpp
+++ b/include/booking_manager.hpp
@@ -25,7 +25,7 @@
     #ifdef BOOKING_EXPORTS
         #define BOOKING_API __declspec(dllexport)
     #else
-        #define BOOKING_API __declspec(dllimport)
+        #define BOOKING_API 
     #endif
 #else
     #define BOOKING_API __attribute__((visibility("default")))

--- a/include/movie.hpp
+++ b/include/movie.hpp
@@ -7,7 +7,7 @@
     #ifdef BOOKING_EXPORTS
         #define BOOKING_API __declspec(dllexport)
     #else
-        #define BOOKING_API __declspec(dllimport)
+        #define BOOKING_API 
     #endif
 #else
     #define BOOKING_API __attribute__((visibility("default")))

--- a/include/observerbase.hpp
+++ b/include/observerbase.hpp
@@ -7,7 +7,7 @@
     #ifdef BOOKING_EXPORTS
         #define BOOKING_API __declspec(dllexport)
     #else
-        #define BOOKING_API __declspec(dllimport)
+        #define BOOKING_API 
     #endif
 #else
     #define BOOKING_API __attribute__((visibility("default")))

--- a/include/seat.hpp
+++ b/include/seat.hpp
@@ -7,7 +7,7 @@
     #ifdef BOOKING_EXPORTS
         #define BOOKING_API __declspec(dllexport)
     #else
-        #define BOOKING_API __declspec(dllimport)
+        #define BOOKING_API 
     #endif
 #else
     #define BOOKING_API __attribute__((visibility("default")))

--- a/include/theater.hpp
+++ b/include/theater.hpp
@@ -11,7 +11,7 @@
     #ifdef BOOKING_EXPORTS
         #define BOOKING_API __declspec(dllexport)
     #else
-        #define BOOKING_API __declspec(dllimport)
+        #define BOOKING_API 
     #endif
 #else
     #define BOOKING_API __attribute__((visibility("default")))

--- a/include/ui.hpp
+++ b/include/ui.hpp
@@ -7,7 +7,7 @@
     #ifdef BOOKING_EXPORTS
         #define BOOKING_API __declspec(dllexport)
     #else
-        #define BOOKING_API __declspec(dllimport)
+        #define BOOKING_API 
     #endif
 #else
     #define BOOKING_API __attribute__((visibility("default")))


### PR DESCRIPTION
1. Redefined BOOKING_API Macro in case of windows & STATIC Library as it does not make any sense to import dll